### PR TITLE
[dnf-yum] Add dnf / yum proxy configuration capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Configure the proxy port.
 
 Configure proxy exceptions like e.g. local hosts.
 
+    dnf_proxy_server: "{{ common_proxy_server }}"
+    dnf_proxy_port: "{{ common_proxy_port }}"
+    dnf_proxy_username: ""
+    dnf_proxy_password: ""
+
+Configure yum or dnf proxy. Set to blank to remove.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,14 @@ common_proxy_stable_os:
   - Ubuntu 20
 
 # Common Management Selections:
-common_proxy_apache2_configure: 'false'
-common_proxy_apt_configure: 'false'
-common_proxy_bash_configure: 'false'
-common_proxy_git_configure: 'false'
-common_proxy_profile_configure: 'false'
-common_proxy_wget_configure: 'false'
+common_proxy_apache2_configure: False
+common_proxy_apt_configure: False
+common_proxy_bash_configure: False
+common_proxy_dnf_yum_configure: False
+common_proxy_git_configure: False
+common_proxy_profile_configure: False
+common_proxy_wget_configure: False
+
 
 common_proxy_server: 127.0.0.1
 common_proxy_port: 8080
@@ -30,3 +32,10 @@ common_proxy_exceptions:
 
 common_proxy_apt_external_repositories: []
 common_proxy_apt_exceptions: []
+
+# Yum / dnf vars
+# Set to blank "" to remove lines from dnf configuration
+dnf_proxy_server: "{{ common_proxy_server }}"
+dnf_proxy_port: "{{ common_proxy_port }}"
+dnf_proxy_username: ""
+dnf_proxy_password: ""

--- a/tasks/dnf_yum.yml
+++ b/tasks/dnf_yum.yml
@@ -1,0 +1,61 @@
+---
+- name: Prepare state of settings
+  set_fact:
+    proxy_state: "{{ 'absent' if (dnf_proxy_server == '' or dnf_proxy_port == '') else 'present'}}"
+    username_state: "{{ 'absent' if dnf_proxy_username == '' else 'present'}}"
+    password_state: "{{ 'absent' if dnf_proxy_password == '' else 'present'}}"
+
+
+- name: Configure proxy settings for dnf
+  ini_file:
+    dest: /etc/dnf/dnf.conf
+    section: main
+    option: proxy
+    value: "http://{{ dnf_proxy_server }}:{{ dnf_proxy_port }}"
+    state: "{{ proxy_state }}"
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Configure proxy_username for dnf
+  ini_file:
+    dest: /etc/dnf/dnf.conf
+    section: main
+    option: proxy_username
+    value: "{{ dnf_proxy_username }}"
+    state: "{{ username_state }}"
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Configure proxy_password for dnf
+  ini_file:
+    dest: /etc/dnf/dnf.conf
+    section: main
+    option: proxy_password
+    value: "{{ dnf_proxy_password }}"
+    state: "{{ password_state }}"
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Configure proxy settings for yum
+  ini_file:
+    dest: /etc/yum/yum.conf
+    section: main
+    option: proxy
+    value: "http://{{ dnf_proxy_server }}:{{ dnf_proxy_port }}"
+    state: "{{ proxy_state }}"
+
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Configure proxy_username for yum
+  ini_file:
+    dest: /etc/yum/yum.conf
+    section: main
+    option: proxy_username
+    state: "{{ username_state }}"
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Configure password for dnf
+  ini_file:
+    dest: /etc/yum/yum.conf
+    section: main
+    option: proxy_password
+    value: "{{ dnf_proxy_password }}"
+    state: "{{ password_state }}"
+  when: ansible_pkg_mgr == 'yum'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,10 @@
   include_tasks: apt.yml
   when: common_proxy_apt_configure and ansible_pkg_mgr == "apt"
 
+- name: "Include Proxy for dnf / yum Playbook."
+  include_tasks: dnf_yum.yml
+  when: common_proxy_dnf_yum_configure and (ansible_pkg_mgr == "dnf" or ansible_pkg_mgr == "yum")
+
 - name: "Include Proxy for Apache2 Playbook."
   include_tasks: apache2.yml
   when: common_proxy_apache2_configure


### PR DESCRIPTION
Add yum or dnf proxy configuration based on ansible_pkg_mgr fact (yum or dnf) as described in #1 
Handle username and password too.
Default to common_proxy_server and port.