### PR TITLE
[apt/aptitude] handle different proxy for common and apt / aptitude.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Configure the proxy port.
 
 Configure proxy exceptions like e.g. local hosts.
 
+    apt_proxy_server: "{{ common_proxy_server }}"
+    apt_proxy_port: "{{ common_proxy_port }}"
+    apt_proxy_username: ""
+    apt_proxy_password: ""
+    apt_proxy_exceptions: [ ]
+
+Configure proxy for apt / aptitude. Default to common_proxy. Set to blank to remove.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,12 @@ common_proxy_stable_os:
   - Ubuntu 20
 
 # Common Management Selections:
-common_proxy_apache2_configure: 'false'
-common_proxy_apt_configure: 'false'
-common_proxy_bash_configure: 'false'
-common_proxy_git_configure: 'false'
-common_proxy_profile_configure: 'false'
-common_proxy_wget_configure: 'false'
+common_proxy_apache2_configure: False
+common_proxy_apt_configure: False
+common_proxy_bash_configure: False
+common_proxy_git_configure: False
+common_proxy_profile_configure: False
+common_proxy_wget_configure: False
 
 common_proxy_server: 127.0.0.1
 common_proxy_port: 8080
@@ -28,5 +28,8 @@ common_proxy_exceptions:
   - 127.0.0.0/8
   - ::1
 
-common_proxy_apt_external_repositories: []
-common_proxy_apt_exceptions: []
+apt_proxy_server: "{{ common_proxy_server }}"
+apt_proxy_port: "{{ common_proxy_port }}"
+apt_proxy_username: ""
+apt_proxy_password: ""
+apt_proxy_exceptions: [ ]

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,4 +1,8 @@
 ---
+- name: "Prepare proxy URL for username and password if needed."
+  set_fact:
+    apt_proxy_server_enhanced: "{{ apt_proxy_server if (apt_proxy_username == '' or apt_proxy_password == '') else apt_proxy_username + '@' + apt_proxy_password + ':' + apt_proxy_server }}"
+
 - name: "Configure Proxy for APT."
   template:
    dest: /etc/apt/apt.conf.d/99proxy
@@ -6,3 +10,10 @@
    owner: root
    group: root
    mode: 0644
+  when: apt_proxy_server != ""
+
+- name: "Remove proxy for APT."
+  file:
+    path: '/etc/apt/apt.conf.d/99proxy'
+    state: absent
+  when: apt_proxy_server == "" or apt_proxy_port == ""

--- a/templates/99proxy.j2
+++ b/templates/99proxy.j2
@@ -1,8 +1,10 @@
+# Ansible Managed
+
+Acquire::http::Proxy "http://{{ apt_proxy_server_enhanced }}:{{ apt_proxy_port }}";
+{% if apt_proxy_exceptions|length > 0 %}
 Acquire::http::Proxy {
-{% for external_repository in common_proxy_apt_external_repositories %}
-    {{ external_repository }} "http://{{ common_proxy_server }}:{{ common_proxy_port }}";
-{% endfor %}
-{% for proxy_exception in common_proxy_apt_exceptions %}
+{% for proxy_exception in apt_proxy_exceptions %}
     {{ proxy_exception }} DIRECT;
 {% endfor %}
 }
+{% endif %}


### PR DESCRIPTION
This PR let us configure a different server than the common system one for apt / aptitude.
It also adds a removing proxy ability.
This is a part of this issue #1

It leads to a functional change : 
The external_repositories vars are removed and the apt_proxy is default instead.
I can rework it to take it back but it seems less intrusive.