### PR TITLE
Add systemd default environment proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available variables are listed below, along with default values (see `defaults/m
     common_proxy_git_configure: false
     common_proxy_profile_configure: false
     common_proxy_wget_configure: false
+    common_proxy_systemd_configure: false
 
 Choose which parts of the system should be configured with a proxy.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,12 @@ common_proxy_stable_os:
   - Ubuntu 20
 
 # Common Management Selections:
-common_proxy_apache2_configure: 'false'
-common_proxy_apt_configure: 'false'
-common_proxy_bash_configure: 'false'
-common_proxy_git_configure: 'false'
-common_proxy_profile_configure: 'false'
-common_proxy_wget_configure: 'false'
+common_proxy_apache2_configure: False
+common_proxy_apt_configure: False
+common_proxy_bash_configure: False
+common_proxy_git_configure: False
+common_proxy_profile_configure: False
+common_proxy_wget_configure: False
 
 common_proxy_server: 127.0.0.1
 common_proxy_port: 8080

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ common_proxy_bash_configure: False
 common_proxy_git_configure: False
 common_proxy_profile_configure: False
 common_proxy_wget_configure: False
+common_proxy_systemd_configure: False
 
 common_proxy_server: 127.0.0.1
 common_proxy_port: 8080

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,13 +15,13 @@ common_proxy_stable_os:
   - Ubuntu 20
 
 # Common Management Selections:
-common_proxy_apache2_configure: False
-common_proxy_apt_configure: False
-common_proxy_bash_configure: False
-common_proxy_git_configure: False
-common_proxy_profile_configure: False
-common_proxy_wget_configure: False
-common_proxy_systemd_configure: False
+common_proxy_apache2_configure: 'false'
+common_proxy_apt_configure: 'false'
+common_proxy_bash_configure: 'false'
+common_proxy_git_configure: 'false'
+common_proxy_profile_configure: 'false'
+common_proxy_wget_configure: 'false'
+common_proxy_systemd_configure: 'false'
 
 common_proxy_server: 127.0.0.1
 common_proxy_port: 8080

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,7 @@
 - name: "Include Proxy for Apache2 Playbook."
   include_tasks: apache2.yml
   when: common_proxy_apache2_configure
+
+- name: "Include Proxy as default for systemd."
+  include_tasks: systemd.yml
+  when: common_proxy_systemd_configure

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,0 +1,29 @@
+---
+- block:
+  - name: "Ensure systemd configuration directory exists."
+    file:
+      dest: /etc/systemd/system.conf.d
+      state : directory
+      mode: 0755
+      owner: root
+      group: root      
+
+  - name: "Configure proxy as systemd default."
+    template:
+      dest: /etc/systemd/system.conf.d/99proxy.conf
+      src: 99proxy.conf.j2
+      mode: 0644
+      owner: root
+      group: root
+
+  - name: "Reload systemd configuration."
+    systemd:
+      daemon-reload: yes
+
+  when: common_proxy_server != "" and common_proxy_port != ""
+
+- name: "Remove proxy from systemd default."
+  file:
+    dest: /etc/systemd/system.conf.d/99proxy.conf
+    state: absent
+  when: common_proxy_server == "" or common_proxy_port == ""

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -16,10 +16,6 @@
       owner: root
       group: root
 
-  - name: "Reload systemd configuration."
-    systemd:
-      daemon-reload: yes
-
   when: common_proxy_server != "" and common_proxy_port != ""
 
 - name: "Remove proxy from systemd default."
@@ -27,3 +23,8 @@
     dest: /etc/systemd/system.conf.d/99proxy.conf
     state: absent
   when: common_proxy_server == "" or common_proxy_port == ""
+
+
+- name: "Reload systemd configuration."
+  systemd:
+    daemon-reload: yes

--- a/templates/99proxy.conf.j2
+++ b/templates/99proxy.conf.j2
@@ -4,6 +4,6 @@
 DefaultEnvironment="http_proxy=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
 "HTTP_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
 "https_proxy=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
-"HTTPS_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}"
-"no_proxy=localhost{% for proxy_exception in common_proxy_exceptions %}, {{ proxy_exception }}{% endfor %}"
+"HTTPS_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
+"no_proxy=localhost{% for proxy_exception in common_proxy_exceptions %}, {{ proxy_exception }}{% endfor %}" \
 "NO_PROXY=localhost{% for proxy_exception in common_proxy_exceptions %}, {{ proxy_exception }}{% endfor %}"

--- a/templates/99proxy.conf.j2
+++ b/templates/99proxy.conf.j2
@@ -5,3 +5,5 @@ DefaultEnvironment="http_proxy=http://{{ common_proxy_server }}:{{ common_proxy_
 "HTTP_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
 "https_proxy=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
 "HTTPS_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}"
+"no_proxy=localhost{% for proxy_exception in common_proxy_exceptions %}, {{ proxy_exception }}{% endfor %}"
+"NO_PROXY=localhost{% for proxy_exception in common_proxy_exceptions %}, {{ proxy_exception }}{% endfor %}"

--- a/templates/99proxy.conf.j2
+++ b/templates/99proxy.conf.j2
@@ -1,0 +1,7 @@
+# Ansible Managed
+
+[Manager]
+DefaultEnvironment="http_proxy=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
+"HTTP_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
+"https_proxy=http://{{ common_proxy_server }}:{{ common_proxy_port }}" \
+"HTTPS_PROXY=http://{{ common_proxy_server }}:{{ common_proxy_port }}"


### PR DESCRIPTION
This branch add systemd proxy settings as default environment for systemd unit ( doc. (here)[https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html] )
It's part of work as described here #1 
